### PR TITLE
Zeroing peaks

### DIFF
--- a/ofxMaxim/ofxMaxim/libs/maxiFFT.cpp
+++ b/ofxMaxim/ofxMaxim/libs/maxiFFT.cpp
@@ -241,6 +241,7 @@ void maxiFFTOctaveAnalyzer::setup(float samplingRate, int nBandsInTheFFT, int nA
     nAverages = avgidx;
     averages = new float[nAverages];
     peaks = new float[nAverages];
+    memset(peaks, 0, sizeof(float) * nAverages);
     peakHoldTimes = new int[nAverages];
     peakHoldTime = 0; // arbitrary
     peakDecayRate = 0.9f; // arbitrary


### PR DESCRIPTION
Hello,
The array of peak floats was not being set to 0.0f. Add it in here.

(Perhaps this is due to my implementation, sorry if it is!)
Thanks,
Ross
