### PR TITLE
add missing #include <cstdlib>

### DIFF
--- a/ofxMaxim/ofxMaxim/libs/maxiMFCC.h
+++ b/ofxMaxim/ofxMaxim/libs/maxiMFCC.h
@@ -15,6 +15,7 @@
 #include "maxiFFT.h"
 #include <math.h>
 #include <iostream>
+#include <cstdlib>
 #ifdef __APPLE_CC__
 #include <Accelerate/Accelerate.h>
 #endif


### PR DESCRIPTION
codeblocks was giving arror :
of\addons\ofxMaxim\libs\maxiMFCC.h|62|error: there are no arguments to
'malloc' that depend on a template parameter, so a declaration of
'malloc' must be available [-fpermissive]|
