### PR TITLE
fixed wav file reading to account for extra bytes in some format chunks

### DIFF
--- a/maximilian.cpp
+++ b/maximilian.cpp
@@ -602,7 +602,7 @@ bool maxiSample::read()
 		//ignore any extra chunks
 		char chunkID[5]="";
 		chunkID[4] = 0;
-		int filePos = 36;
+		int filePos = 20 + mySubChunk1Size;
 		while(!datafound && !inFile.eof()) {
 			inFile.seekg(filePos, ios::beg);
 			inFile.read((char*) &chunkID, sizeof(char) * 4);

--- a/ofxMaxim/ofxMaxim/libs/maximilian.cpp
+++ b/ofxMaxim/ofxMaxim/libs/maximilian.cpp
@@ -597,7 +597,7 @@ bool maxiSample::read()
 		//ignore any extra chunks
 		char chunkID[5]="";
 		chunkID[4] = 0;
-		int filePos = 36;
+		int filePos = 20 + mySubChunk1Size;
 		while(!datafound && !inFile.eof()) {
 			inFile.seekg(filePos, ios::beg);
 			inFile.read((char*) &chunkID, sizeof(char) * 4);


### PR DESCRIPTION
Reading some wav files causes a crash as `myDataSize` is read from the wrong position. On little endian machines (e.g. Intel), this normally results in a malloc error.

The fix uses `mySubChunk1Size` (previously unused) to account for the possible 2 extra bytes at the end of the format chunk, which seem to be present it many modern wav files.
