### PR TITLE
maxiBark

### DIFF
--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Maximilian is an audio synthesis and signal processing library written in C++. I
 - effects including delay, distortion, chorus, flanging
 - granular synthesis, including time and pitch stretching
 - atom synthesis
-- realtime music information retrieval functions: spectrum analysis, spectral features, octave analysis, and MFCCs
+- realtime music information retrieval functions: spectrum analysis, spectral features, octave analysis, Bark scale analysis, and MFCCs
 - example projects for Windows and MacOS, using command line and OpenFrameworks environments
 
 

--- a/ofxMaxim/ofxMaxim/install.xml
+++ b/ofxMaxim/ofxMaxim/install.xml
@@ -21,6 +21,8 @@
 			    <file>../../../addons/ofxMaxim/libs/fft.cpp</file>
 			    <file>../../../addons/ofxMaxim/libs/fftOctaveAnalyzer.h</file>
 			    <file>../../../addons/ofxMaxim/libs/fftOctaveAnalyzer.cpp</file>
+                <file>../../../addons/ofxMaxim/libs/maxiBark.cpp</file>
+                <file>../../../addons/ofxMaxim/libs/maxiBark.h</file>
 			    <file>../../../addons/ofxMaxim/libs/maximilian.h</file>
 			    <file>../../../addons/ofxMaxim/libs/maximilian.cpp</file>
 		    </folder>

--- a/ofxMaxim/ofxMaxim/libs/maxiBark.cpp
+++ b/ofxMaxim/ofxMaxim/libs/maxiBark.cpp
@@ -1,0 +1,10 @@
+/*
+ *  maxiBark.cpp
+ *  Bark scale loudness
+ *
+ *  Created by Jakub on 01/12/2014.
+ *  Copyright 2014 Goldsmiths Creative Computing. All rights reserved.
+ *
+ */
+
+#include "maxiBark.h"

--- a/ofxMaxim/ofxMaxim/libs/maxiBark.h
+++ b/ofxMaxim/ofxMaxim/libs/maxiBark.h
@@ -1,0 +1,133 @@
+/*
+ *  maxiBark.cpp
+ *  Bark scale loudness
+ *
+ *  Created by Jakub on 01/12/2014.
+ *  Copyright 2014 Goldsmiths Creative Computing. All rights reserved.
+ *
+ */
+
+#pragma once
+#pragma pack(16)
+
+#include "maxiFFT.h"
+#include <math.h>
+#include <iostream>
+//#include <algorithm>
+#include <cstdlib>
+#ifdef __APPLE_CC__
+#include <Accelerate/Accelerate.h>
+#endif
+
+using namespace std;
+
+//convert to Bark scale (Zwicker, 1961)
+inline double hzToBark(double hz) {
+    return 13.0*atan(hz/1315.8) + 3.5*atan(pow((hz/7518.0),2));
+}
+
+inline double binToHz(unsigned int bin, unsigned int sR, unsigned int bS) {
+    return bin*sR/bS;
+}
+
+template <class T>
+
+class maxiBarkScaleAnalyser {
+public:
+    int NUM_BARK_BANDS;
+    
+    void setup(unsigned int sR, unsigned int bS) {
+        this->sampleRate = sR;
+        this->bufferSize = bS;
+        specSize = bS/2;
+        NUM_BARK_BANDS = 24;
+        for (int i=0; i<specSize; i++) {
+            barkScale[i] = hzToBark(binToHz(i, sR, bS));
+        }
+        
+        bbLimits[0] = 0;
+        int currentBandEnd = barkScale[specSize-1]/NUM_BARK_BANDS;
+        int currentBand = 1;
+        
+        for(int i = 0; i<specSize; i++){
+            while(barkScale[i] > currentBandEnd) {
+                bbLimits[currentBand] = i;
+                currentBand++;
+                currentBandEnd = currentBand*barkScale[specSize-1]/NUM_BARK_BANDS;
+            }
+        }
+        
+        bbLimits[NUM_BARK_BANDS] = specSize-1;
+    };
+    
+    double* specificLoudness(float* normalisedSpectrum) {
+        for (int i = 0; i < NUM_BARK_BANDS; i++){
+            double sum = 0;
+            for (int j = bbLimits[i] ; j < bbLimits[i+1] ; j++) {
+                
+                sum += normalisedSpectrum[j];
+            }
+            specific[i] = pow(sum,0.23);
+        }
+        
+        return specific;
+    };
+    
+    double* relativeLoudness(float* normalisedSpectrum) {
+        for (int i = 0; i < NUM_BARK_BANDS; i++){
+            double sum = 0;
+            for (int j = bbLimits[i] ; j < bbLimits[i+1] ; j++) {
+                
+                sum += normalisedSpectrum[j];
+            }
+            specific[i] = pow(sum,0.23);
+        }
+        
+        double max = 0;
+        for (int i = 0; i < NUM_BARK_BANDS; i++){
+            if (specific[i] > max) max = specific[i];
+        }
+        
+        for (int i = 0; i < NUM_BARK_BANDS; i++){
+            relative[i] = specific[i]/max;
+        }
+        
+        return relative;
+    };
+    
+    double* totalLoudness(float* normalisedSpectrum) {
+        for (int i = 0; i < NUM_BARK_BANDS; i++){
+            double sum = 0;
+            for (int j = bbLimits[i] ; j < bbLimits[i+1] ; j++) {
+                
+                sum += normalisedSpectrum[j];
+            }
+            specific[i] = pow(sum,0.23);
+        }
+        
+        total[0] = 0;
+        
+        for (int i = 0; i < 24; i++){
+            total[0] += specific[i];
+        }
+        
+        return total;
+    };
+    
+private:
+    int bbLimits[24];
+    unsigned int sampleRate, bufferSize, specSize;
+    double barkScale[2048];
+    double specific[24];
+    double relative[24];
+    double total[1];
+    
+};
+
+typedef maxiBarkScaleAnalyser<double> maxiBark;
+
+
+
+
+
+

--- a/ofxMaxim/ofxMaxim/src/ofxMaxim.h
+++ b/ofxMaxim/ofxMaxim/src/ofxMaxim.h
@@ -37,6 +37,7 @@
 #include "maxiFFT.h"
 #include "maxiGrains.h"
 #include "maxiMFCC.h"
+#include "maxiBark.h"
 
 
 typedef maxiMix ofxMaxiMix;


### PR DESCRIPTION
maxiBark
=======

this is an implementation of Bark scale loudness, similar to the one in [YAAFE](http://yaafe.sourceforge.net/ "Yaafe") and [Meyda](http://github.com/hughrawlinson/meyda "Meyda"). It can be used just like _maxiMFCC,_ with a setup function and three main functions, which correspond to 3 types of Bark loudness described [here](http://recherche.ircam.fr/anasyn/peeters/ARTICLES/Peeters_2003_cuidadoaudiofeatures.pdf "Peeters"):

+ `specificLoudness` is an array of absolute loudness values for each of the bark bands
+ `relativeLoudness` is also an array of loudness values, but relative to the loudest band
+ `totalLoudness` is the sum of absolute loudness of all bands

Example code:
--------------------

```cpp
void ofApp::audioReceived 	(float * input, int bufferSize, int nChannels){

    for (int i = 0; i < bufferSize; i++){        
        lAudioIn[i] = input[i*2];
        rAudioIn[i] = input[i*2+1];
        
        bool isFFT = fft.process(lAudioIn[i]);
        if (isFFT) {
            specLoudness = bark.specificLoudness(fft.magnitudes);
            relLoudness = bark.relativeLoudness(fft.magnitudes);
            totLoudness = bark.totalLoudness(fft.magnitudes);
            
            //TOTAL
            printf("total: %f  \n", totalLoudness[0]);
            
            //SPEC or REL
            for (int x = 0; x < 24; x++) {
                printf("specific: %i, %f \n relative: %i, %f \n ", x, specificLoudness[x], x, relativeLoudness[x]);
            }
        }
    }
}
```
