### PR TITLE
Added runtime assertion for undefined VORBIS

### DIFF
--- a/maximilian.cpp
+++ b/maximilian.cpp
@@ -560,6 +560,8 @@ bool maxiSample::loadOgg(string fileName, int channel) {
         }
     }
 	return result; // this should probably be something more descriptive
+#else
+  assert(false); // called but VORBIS not defined!
 #endif
     return 0;
 }

--- a/maximilian.h
+++ b/maximilian.h
@@ -40,6 +40,7 @@
 #include <iostream>
 #include <fstream>
 #include <string.h>
+#include <cassert>
 #include <cstdlib>
 #include "math.h"
 #ifdef _WIN32 //|| _WIN64


### PR DESCRIPTION
New users might not end up digging through the actual
implementation to uncomment the VORBIS definition right away.
The runtime assertion will fire if a user calls loadOGG without
the definition, thus reminding to uncomment.
