### PR TITLE
fix compile error in recent master

### DIFF
--- a/openFrameworks/ofxMaxim/libs/maxiGrains.h
+++ b/openFrameworks/ofxMaxim/libs/maxiGrains.h
@@ -126,7 +126,7 @@ private:
 class maxiGrainBase {
 public:
     virtual double play() {}
-    virtual ~maxiGrainBase() {}
+    virtual ~maxiGrainBase() { return 0.0; }
     bool finished;
 };
 


### PR DESCRIPTION
Without this fix, the addon does not compile with the latest OF master version (that soon will be the new release, 0.10), this was the error


/ofxMaxim/libs/maxiGrains.h:128: error: no return statement in function returning non-void [-Werror=return-type]
     virtual double play() {}
