### PR TITLE
include limits

### DIFF
--- a/src/maximilian.h
+++ b/src/maximilian.h
@@ -39,6 +39,7 @@
 #include <fstream>
 #include <string.h>
 #include <cstdlib>
+#include <limits>
 #include "math.h"
 #include <cmath>
 #include <vector>


### PR DESCRIPTION
This is necessary because `std::numeric_limits::max()` is used in `maximilian.h`.