### PR TITLE
add setSampleRate() to maxiPolyBLEP class

### DIFF
--- a/src/libs/maxiPolyBLEP.h
+++ b/src/libs/maxiPolyBLEP.h
@@ -59,6 +59,11 @@ public:
     blep.setPulseWidth(pw);
   }
 
+  /* Set sample rate */
+  void setSampleRate(double sampleRate) {
+    blep.setSampleRate(sampleRate);
+  }
+
 private:
   PolyBLEP blep = PolyBLEP(44100);
 


### PR DESCRIPTION
The `maxiPolyBLEP` class doesn't use the value of `maxiSettings::sampleRate,` so we need a way to set the sample rate after making an instance of maxiPolyBLEP.