### PR TITLE
add sync() to maxiPolyBLEP

### DIFF
--- a/src/libs/maxiPolyBLEP.h
+++ b/src/libs/maxiPolyBLEP.h
@@ -59,6 +59,11 @@ public:
     blep.setPulseWidth(pw);
   }
 
+  /* Sync modulatoin */
+  void sync(double phase) {
+    blep.sync(phase);
+  }
+
 private:
   PolyBLEP blep = PolyBLEP(44100);
 


### PR DESCRIPTION
This patch lets  `maxiPolyBLEP` to be able to use the `sync()` method of the `PolyBLEP` class.