### PR TITLE
fixed retrigger bug in maxiEnvGen::play()

### DIFF
--- a/src/maximilian.h
+++ b/src/maximilian.h
@@ -2316,6 +2316,7 @@ class CHEERP_EXPORT maxiEnvGen {
                         }
                         if (retrigger) {
                             if (retriggerDetector.onZX(trigger)) {
+                                nxcHappened = false;
                                 reset();
                             }
                         }
@@ -2336,6 +2337,7 @@ class CHEERP_EXPORT maxiEnvGen {
                     }
                     if (retrigger) {
                         if (retriggerDetector.onZX(trigger)) {
+                            nxcHappened = false;
                             reset();
                         }
                     }


### PR DESCRIPTION
When retriggered, the program does not set `nxcHappened` to be `false`, so the envelope won't stay at the `HOLDING` state in the next cycle. For example, if I set up an ASR envelope, and retrigger it when releasing, it will perform like an AR envelope instead of an ASR envelope.

I let the program to set `nxcHappened = false` when retriggered and now the envelope should work fine.