### PR TITLE
Fix compile error on gcc13

### DIFF
--- a/src/maximilian.h
+++ b/src/maximilian.h
@@ -39,6 +39,7 @@
 #include <fstream>
 #include <string.h>
 #include <cstdlib>
+#include <cstdint>
 #include <limits>
 #include "math.h"
 #include <cmath>


### PR DESCRIPTION
When compiling Maximilian with gcc13 I've encountered a problem which I described in issue: https://github.com/micknoise/Maximilian/issues/140. Here is my solution for this issue - after fixing it Maximilian builds well with gcc13, so I guess it's worth merging.
I've tested it locally with docker on images gcc12, gcc11, gcc10 and gcc9 so it shouldn't break compilation on older versions of gcc 